### PR TITLE
Add support for other sequencing centers

### DIFF
--- a/pytcga/__init__.py
+++ b/pytcga/__init__.py
@@ -1,4 +1,4 @@
-from pytcga.tcga_requests import tcga_request
+from pytcga.tcga_requests import tcga_request, RequestError
 from pytcga.tcga_clinical import load_clinical_data, load_patient_data, load_patient_samples, load_patient_analytes, load_treatments, load_sample_and_analytes, load_aliquots
 from pytcga.tcga_mutations import load_mutation_data
 from pytcga.tcga_rna import load_rnaseq_data


### PR DESCRIPTION
Previously, we were failing to grab the mutation data for studies that were sequenced at a center different than `BI`. This adds support for other sequencing centers by handling the non-standard REST-like errors from the TCGA server. 

An example of a page with such an error (asking for mutation data for the brca study from the bi center): http://tcga-data.nci.nih.gov/tcga/damws/jobprocess/json?disease=BRCA&level=2&platform=Mutation%20Calling&center=BI
